### PR TITLE
Single-line audit messages

### DIFF
--- a/inspektr-audit/src/main/java/com/github/inspektr/audit/support/AbstractStringAuditTrailManager.java
+++ b/inspektr-audit/src/main/java/com/github/inspektr/audit/support/AbstractStringAuditTrailManager.java
@@ -32,7 +32,7 @@ import com.github.inspektr.audit.AuditTrailManager;
 public abstract class AbstractStringAuditTrailManager implements AuditTrailManager {
 
     /** Use multi-line output by default **/
-    private Boolean useSingleLine = false;
+    private boolean useSingleLine = false;
 
     /** Separator for single line log entries */
     private String entrySeparator = ",";
@@ -45,7 +45,7 @@ public abstract class AbstractStringAuditTrailManager implements AuditTrailManag
         this.entrySeparator = separator;
     }
 
-    public void setUseSingleLine(final Boolean useSingleLine) {
+    public void setUseSingleLine(final boolean useSingleLine) {
         this.useSingleLine = useSingleLine;
     }
 


### PR DESCRIPTION
The multi-line format of audit messages the inspektr uses for the Console and SLF4J loggers is easy to read, but parsing it is a pain.  I added the ability to log to a single line to make pulling it into Splunk or Graylog easier.

Configuration is straight-forward (it defaults to the multi-line format, so the changes are optional):

```
<bean id="auditTrailManager" class="com.github.inspektr.audit.support.Slf4jLoggingAuditTrailManager" 
      p:useSingleLine="True" 
      p:entrySeparator="|" />
```
